### PR TITLE
Enable Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: go
+go:
+  - 1.4.3
+  - 1.5.3
+  - 1.6
+
+sudo: false
+
+notifications:
+  email: false
+
+go_import_path: github.com/sensorbee/jubatus
+
+before_install:
+  - env
+  - lsb_release -a
+  - go version
+
+install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/pierrre/gotestcover
+  - go get -t -d -v ./...
+
+script:
+  - go build -v ./...
+  - gotestcover -v -covermode=count -coverprofile=.profile.cov ./...
+
+after_success:
+  - if [ "$TRAVIS_GO_VERSION" = "1.6" ]; then goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN; fi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
+[![Build Status](https://travis-ci.org/sensorbee/jubatus.svg?branch=master)](https://travis-ci.org/sensorbee/jubatus)
+[![Coverage Status](https://coveralls.io/repos/github/sensorbee/jubatus/badge.svg?branch=master)](https://coveralls.io/github/sensorbee/jubatus?branch=master)
+
 # Machine learning plugin for SensorBee


### PR DESCRIPTION
I prepared Travis-CI and Coveralls like sensorbee/pymlstate#11 and sensorbee/sensorbee#49.
This doesn't contain `go vet` and `golint`.
